### PR TITLE
역사지도 뷰를 구현하였습니다

### DIFF
--- a/FREEWAY/FREEWAY/Presentation/StationDetailBottomSheetView/StationDetailView/StationMapWebView.swift
+++ b/FREEWAY/FREEWAY/Presentation/StationDetailBottomSheetView/StationDetailView/StationMapWebView.swift
@@ -8,9 +8,13 @@
 import UIKit
 import SnapKit
 import Then
+import WebKit
 
 final class StationMapWebView: UIView {
     
+    private var data = MockData.mockStationDetail
+    lazy var webURL: String = data.stationImageUrl
+    private var webView: WKWebView!
     private let GuidanceLabel = UILabel().then {
         $0.text = "손으로 확대, 축소가 가능해요"
         $0.textColor = .black
@@ -21,7 +25,9 @@ final class StationMapWebView: UIView {
     init() {
         super.init(frame: .zero)
         backgroundColor = Pallete.backgroundGray.color
+        setWebView()
         setupLayout()
+        self.insetsLayoutMarginsFromSafeArea = true
     }
     
     required init?(coder: NSCoder) {
@@ -32,10 +38,25 @@ final class StationMapWebView: UIView {
 
 private extension StationMapWebView {
     func setupLayout() {
+        self.addSubview(webView)
+        webView.snp.makeConstraints { make in
+            make.top.equalToSuperview()
+            make.leading.trailing.bottom.equalToSuperview()
+        }
         self.addSubview(GuidanceLabel)
         GuidanceLabel.snp.makeConstraints { make in
             make.bottom.equalToSuperview()
             make.centerX.equalToSuperview()
+        }
+    }
+    
+    func setWebView() {
+        let webConfiguration = WKWebViewConfiguration()
+        webView = WKWebView(frame: .zero, configuration: webConfiguration)
+        let AppInfoURL = URL(string: webURL)
+        let AppInfoRequest = URLRequest(url: AppInfoURL!)
+        DispatchQueue.main.async {
+            self.webView.load(AppInfoRequest)
         }
     }
 }

--- a/FREEWAY/FREEWAY/Presentation/StationDetailBottomSheetView/StationDetailView/StationMapWebView.swift
+++ b/FREEWAY/FREEWAY/Presentation/StationDetailBottomSheetView/StationDetailView/StationMapWebView.swift
@@ -33,7 +33,6 @@ final class StationMapWebView: UIView {
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-    
 }
 
 private extension StationMapWebView {
@@ -45,7 +44,7 @@ private extension StationMapWebView {
         }
         self.addSubview(GuidanceLabel)
         GuidanceLabel.snp.makeConstraints { make in
-            make.bottom.equalToSuperview()
+            make.bottom.equalToSuperview().offset(-253)
             make.centerX.equalToSuperview()
         }
     }


### PR DESCRIPTION
## 역사지도 뷰를 구현하였습니다.
close #24 

### 📸 구현 화면
<img src = "https://github.com/SeSACTHON-FREE-WAY/FREEWAY-iOS/assets/103012087/a5209451-f454-41cc-a37a-3fe1a72135d1" width = 250>


### 📌 핵심 구현 사항
- WKWebView를 활용하여 역사지도 링크를 웹뷰로 나타내도록 구현하였습니다.

### 남은 작업
- [x] 현재 역사지도 부분만 웹뷰가 불러와지지 않는 이슈가 있어 추후 링크 검증, 웹뷰 교체가 필요할 수 있습니다
- [x] MockData로만 연동시켜놓아 API 연동 시 변경되어야할 부분입니다.